### PR TITLE
#167246521 Fix cors errors on Heroku

### DIFF
--- a/config/settings/default.py
+++ b/config/settings/default.py
@@ -91,10 +91,9 @@ STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')
 
 STATIC_URL = os.environ.get('STATIC_URL')
 
-CORS_ORIGIN_WHITELIST = (
-    '0.0.0.0:4000',
-    'localhost:4000',
-)
+CORS_ORIGIN_ALLOW_ALL = True
+CORS_ALLOW_CREDENTIALS = True
+
 
 AUTH_USER_MODEL = 'authentication.User'
 


### PR DESCRIPTION
#### What does this PR do?

- add cors headers to the `default` config

#### Any background context you want to provide?

- The following error is returned when trying to call the API from the frontend application
![image](https://user-images.githubusercontent.com/6644707/61108314-ac059580-a48a-11e9-87a6-9690d531d757.png)
-This bug fix is intended to resolve that issue

#### What are the relevant pivotal tracker stories?

[#167246521](https://www.pivotaltracker.com/story/show/167246521)