### PR TITLE
#167413536 Change the reset link to point to the frontend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,7 @@ export DATABASE_HOST='db_host'
 export DATABASE_USER='db_user'
 export DATABASE_PASSWORD='db_password'
 export DATABASE_PORT='db_port'
+export RESET_PASSWORD_REDIRECT_DOMAIN='https://localhost:4000'
 export DJANGO_SETTINGS_MODULE=config.settings.(development/testing/production/staging)
 python manage.py makemigrations --settings=config.settings.(development/production/staging/testing)
 python manage.py migrate --settings=config.settings.(development/production/staging/testing)

--- a/authors/apps/articles/models.py
+++ b/authors/apps/articles/models.py
@@ -49,6 +49,9 @@ class Article(models.Model):
         'profiles.Profile',
         on_delete=models.CASCADE,
         related_name='articles')
+    
+    class Meta:
+        ordering=['-created_at']
 
     def _get_unique_slug(self):
         slug = slugify(self.title)

--- a/authors/apps/authentication/serializers.py
+++ b/authors/apps/authentication/serializers.py
@@ -203,7 +203,7 @@ class ResetEmailSerializer(serializers.ModelSerializer):
         try:
             valid_email = User.objects.get(email=value)
         except Exception:
-            raise serializers.ValidationError(f"{value} email is Invalid")
+            raise serializers.ValidationError(f"{value} is Invalid")
         return value
 
     class Meta:

--- a/authors/apps/authentication/views.py
+++ b/authors/apps/authentication/views.py
@@ -1,4 +1,5 @@
 import json
+import os
 
 from django.conf import settings
 from django.contrib.sites.shortcuts import get_current_site
@@ -154,10 +155,11 @@ class ResetPasswordEmail(CreateAPIView):
             current_site = get_current_site(request)
             token = password_rest_token.make_token(user),
             uidb64 = urlsafe_base64_encode(force_bytes(data['email'])).decode()
+            RESET_PASSWORD_REDIRECT_DOMAIN = os.environ['RESET_PASSWORD_REDIRECT_DOMAIN']
             body = json.dumps({
                 'message': 'Please use the url below to rest your password,\
                             This expires after an hour, Thank you.',
-                'domain': current_site.domain + f'/api/reset/{uidb64}/{token[0]}',
+                'domain': f'{RESET_PASSWORD_REDIRECT_DOMAIN}/reset-password?uuid={uidb64}&token={token[0]}',
             })
             from_email = settings.DEFAULT_FROM_EMAIL
             to_email = data['email']

--- a/config/settings/default.py
+++ b/config/settings/default.py
@@ -91,10 +91,9 @@ STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')
 
 STATIC_URL = os.environ.get('STATIC_URL')
 
-CORS_ORIGIN_WHITELIST = (
-    '0.0.0.0:4000',
-    'localhost:4000',
-)
+CORS_ORIGIN_ALLOW_ALL = True
+CORS_ALLOW_CREDENTIALS = True
+
 
 AUTH_USER_MODEL = 'authentication.User'
 


### PR DESCRIPTION
#### What does this PR do?

- Changes the URL that is used for the password-reset functionality to point to the front-end application

#### Description of Task to be completed?

- change the password reset link that is sent to a user after
  confirming their email to point to the front-end password
  reset page
- store the domain as an environment variable to enable use
  with different domains.

#### How should this be manually tested?

- Using a registered email, make a request to reset a password on the route `/api/password_reset/` passing your email in the body. Use this[ link](https://ah-haven-space.herokuapp.com/#api-password_reset-create)
- If successful, a password reset link will be sent to your email address.
- Login to your email and click the link to be redirected to the frontend's  password reset page

#### What are the relevant pivotal tracker stories?

[#167413536](https://www.pivotaltracker.com/story/show/167413536)
